### PR TITLE
Fix for Ubuntu 14.04 LTS and CentOS 7 with Python 2.7.

### DIFF
--- a/bin/pt-config
+++ b/bin/pt-config
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # pt-config

--- a/bin/pt-index-usage
+++ b/bin/pt-index-usage
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # pt-index-usage

--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # pt-kill

--- a/bin/pt-proc-stat
+++ b/bin/pt-proc-stat
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # pt-proc-stat

--- a/bin/pt-replication-stat
+++ b/bin/pt-replication-stat
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # pt-replication-stat

--- a/bin/pt-session-profiler
+++ b/bin/pt-session-profiler
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # pt-session-profiler

--- a/bin/pt-set-tablespace
+++ b/bin/pt-set-tablespace
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # pt-set-tablespace

--- a/bin/pt-snap-statements
+++ b/bin/pt-snap-statements
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # pt-snap-statements

--- a/bin/pt-stat-snapshot
+++ b/bin/pt-stat-snapshot
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # pt-stat-snapshot

--- a/bin/pt-table-usage
+++ b/bin/pt-table-usage
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # pt-table-usage

--- a/bin/pt-tablespace-usage
+++ b/bin/pt-tablespace-usage
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # pt-tablespace-usage

--- a/bin/pt-verify-checksum
+++ b/bin/pt-verify-checksum
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # pt-verify-checksum

--- a/bin/pt-xact-stat
+++ b/bin/pt-xact-stat
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # pt-xact-stat

--- a/bin/t/regress.sh
+++ b/bin/t/regress.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 _PATH=$PATH
 LANG=C
@@ -123,27 +123,67 @@ echo "wal_level = 'hot_standby'" >> _postgresql.conf
 echo "wal_keep_segments = 8" >> _postgresql.conf
 echo "max_wal_senders = 2" >> _postgresql.conf
 echo "hot_standby = on" >> _postgresql.conf
-testsuite /usr/pgsql-9.0 ./data90 ./out90
+if [ -d /usr/pgsql-9.0 ]; then
+  # RHEL/CentOS
+  testsuite /usr/pgsql-9.0 ./data90 ./out90
+elif [ -d /usr/lib/postgresql/9.0 ]; then
+  # Ubuntu
+  testsuite /usr/lib/postgresql/9.0 ./data90 ./out90
+else
+  echo "passing the regression tests for 9.0"
+fi
 
 # -------------------------------------------------------
 # 9.1
 # -------------------------------------------------------
-testsuite /usr/pgsql-9.1 ./data91 ./out91
+if [ -d /usr/pgsql-9.1 ]; then
+  # RHEL/CentOS
+  testsuite /usr/pgsql-9.1 ./data91 ./out91
+elif [ -d /usr/lib/postgresql/9.1 ]; then
+  # Ubuntu
+  testsuite /usr/lib/postgresql/9.1 ./data91 ./out91
+else
+  echo "passing the regression tests for 9.1"
+fi
 
 # -------------------------------------------------------
 # 9.2
 # -------------------------------------------------------
 echo "track_io_timing = on" >> _postgresql.conf
-testsuite /usr/pgsql-9.2 ./data92 ./out92
+if [ -d /usr/pgsql-9.2 ]; then
+  # RHEL/CentOS
+  testsuite /usr/pgsql-9.2 ./data92 ./out92
+elif [ -d /usr/lib/postgresql/9.2 ]; then
+  # Ubuntu
+  testsuite /usr/lib/postgresql/9.2 ./data92 ./out92
+else
+  echo "passing the regression tests for 9.2"
+fi
 
 # -------------------------------------------------------
 # 9.3
 # -------------------------------------------------------
 # Checksum support
 _INITDB_OPTS="-k"
-testsuite /usr/pgsql-9.3 ./data93 ./out93
+if [ -d /usr/pgsql-9.3 ]; then
+  # RHEL/CentOS
+  testsuite /usr/pgsql-9.3 ./data93 ./out93
+elif [ -d /usr/lib/postgresql/9.3 ]; then
+  # Ubuntu
+  testsuite /usr/lib/postgresql/9.3 ./data93 ./out93
+else
+  echo "passing the regression tests for 9.3"
+fi
 
 # -------------------------------------------------------
 # 9.4
 # -------------------------------------------------------
-testsuite /usr/pgsql-9.4 ./data94 ./out94
+if [ -d /usr/pgsql-9.4 ]; then
+  # RHEL/CentOS
+  testsuite /usr/pgsql-9.4 ./data94 ./out94
+elif [ -d /usr/lib/postgresql/9.4 ]; then
+  # Ubuntu
+  testsuite /usr/lib/postgresql/9.4 ./data94 ./out94
+else
+  echo "passing the regression tests for 9.4"
+fi

--- a/bin/t/test-pt-config.sh
+++ b/bin/t/test-pt-config.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH=$PATH:..:../../deps/shunit2-2.1.6/src
 export PATH

--- a/bin/t/test-pt-index-usage.sh
+++ b/bin/t/test-pt-index-usage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH=$PATH:..:../../deps/shunit2-2.1.6/src
 export PATH

--- a/bin/t/test-pt-kill.sh
+++ b/bin/t/test-pt-kill.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH=$PATH:..:../../deps/shunit2-2.1.6/src
 export PATH

--- a/bin/t/test-pt-proc-stat.sh
+++ b/bin/t/test-pt-proc-stat.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH=$PATH:..:../../deps/shunit2-2.1.6/src
 export PATH

--- a/bin/t/test-pt-replication-stat.sh
+++ b/bin/t/test-pt-replication-stat.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH=$PATH:..:../../deps/shunit2-2.1.6/src
 export PATH
@@ -16,11 +16,7 @@ function setUp()
 
     pgbench -i >> setUp.log 2>&1
 
-    if [ -f $PGHOME/share/contrib/pg_stat_statements.sql ]; then
-	psql -f $PGHOME/share/contrib/pg_stat_statements.sql >> setUp.log 2>&1
-    else
-	psql -c 'create extension pg_stat_statements' >> setUp.log 2>&1
-    fi
+    install_pg_stat_statements >> setUp.log 2>&1
 }
 
 function testReplicationStat001()

--- a/bin/t/test-pt-session-profiler.sh
+++ b/bin/t/test-pt-session-profiler.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH=$PATH:..:../../deps/shunit2-2.1.6/src
 export PATH

--- a/bin/t/test-pt-set-tablespace.sh
+++ b/bin/t/test-pt-set-tablespace.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH=$PATH:..:../../deps/shunit2-2.1.6/src
 export PATH

--- a/bin/t/test-pt-snap-statements.sh
+++ b/bin/t/test-pt-snap-statements.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH=$PATH:..:../../deps/shunit2-2.1.6/src
 export PATH
@@ -16,11 +16,7 @@ function setUp()
 
     pgbench -i >> setUp.log 2>&1
 
-    if [ -f $PGHOME/share/contrib/pg_stat_statements.sql ]; then
-	psql -f $PGHOME/share/contrib/pg_stat_statements.sql >> setUp.log 2>&1
-    else
-	psql -c 'create extension pg_stat_statements' >> setUp.log 2>&1
-    fi
+    install_pg_stat_statements >> setUp.log 2>&1
 
     psql -c 'select pg_stat_statements_reset()' >> setUp.log 2>&1
 }

--- a/bin/t/test-pt-stat-snapshot.sh
+++ b/bin/t/test-pt-stat-snapshot.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH=$PATH:..:../../deps/shunit2-2.1.6/src
 export PATH
@@ -12,16 +12,9 @@ function setUp()
 #    echo "PATH=$PATH"
 #    echo "PGHOME=$PGHOME"
 #    echo "PGDATA=$PGDATA"
-    if [ -f $PGHOME/share/contrib/pg_stat_statements.sql ]; then
-        psql -f $PGHOME/share/contrib/pg_stat_statements.sql >> setUp.log 2>&1
-    else
-        psql -c 'create extension pg_stat_statements' >> setUp.log 2>&1
-    fi
-    if [ -f $PGHOME/share/contrib/pgstattuple.sql ]; then
-        psql -f $PGHOME/share/contrib/pgstattuple.sql >> setUp.log 2>&1
-    else
-        psql -c 'create extension pgstattuple' >> setUp.log 2>&1
-    fi
+
+    install_pg_stat_statements >> setUp.log 2>&1
+    install_pgstattuple >> setUp.log 2>&1
 
     ps auxx > setUp.log
 }

--- a/bin/t/test-pt-table-usage.sh
+++ b/bin/t/test-pt-table-usage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH=$PATH:..:../../deps/shunit2-2.1.6/src
 export PATH

--- a/bin/t/test-pt-tablespace-usage.sh
+++ b/bin/t/test-pt-tablespace-usage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH=$PATH:..:../../deps/shunit2-2.1.6/src
 export PATH

--- a/bin/t/test-pt-verify-checksum.sh
+++ b/bin/t/test-pt-verify-checksum.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH=$PATH:..:../../deps/shunit2-2.1.6/src
 export PATH

--- a/bin/t/test-pt-xact-stat.sh
+++ b/bin/t/test-pt-xact-stat.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PATH=$PATH:..:../../deps/shunit2-2.1.6/src
 export PATH

--- a/bin/t/test_common.sh
+++ b/bin/t/test_common.sh
@@ -19,3 +19,26 @@ function contains()
     fi
 }
 
+function install_pg_stat_statements()
+{
+    _SHARE_DIR=`$PGHOME/bin/pg_config --sharedir`
+
+    if [ -f $_SHARE_DIR/contrib/pg_stat_statements.sql ]; then
+	psql -f $_SHARE_DIR/contrib/pg_stat_statements.sql
+    else
+	psql -c 'create extension pg_stat_statements'
+    fi
+}
+
+function install_pgstattuple()
+{
+    _SHARE_DIR=`$PGHOME/bin/pg_config --sharedir`
+
+    if [ -f $_SHARE_DIR/contrib/pgstattuple.sql ]; then
+	psql -f $_SHARE_DIR/contrib/pgstattuple.sql
+    else
+	psql -c 'create extension pgstattuple'
+    fi
+}
+
+

--- a/docs/en/install.rst
+++ b/docs/en/install.rst
@@ -8,10 +8,11 @@ Supported OS
 
 For a list of Operating System supported.
 
-* Red Hat Enterprise Linux 6
-* CentOS 6
+* Red Hat Enterprise Linux 6 / CentOS 6
+* Red Hat Enterprise Linux 7 / CentOS 7
+* Ubuntu 14.04 LTS
 
-Make sure you have Python2.6 is installed.
+Make sure you have Python2.6 or Python2.7 is installed.
 
 
 PostgreSQL Version

--- a/docs/ja/install.rst
+++ b/docs/ja/install.rst
@@ -8,10 +8,11 @@
 
 サポートされているOSとそのバージョンは以下の通りです。
 
-* Red Hat Enterprise Linux 6
-* CentOS 6
+* Red Hat Enterprise Linux 6 / CentOS 6
+* Red Hat Enterprise Linux 7 / CentOS 7
+* Ubuntu 14.04 LTS
 
-なお、Python2.6がインストールされている必要があります。
+なお、Python2.6またはPython2.7がインストールされている必要があります。
 
 
 PostgreSQLバージョン

--- a/lib/DirectoryTree.py
+++ b/lib/DirectoryTree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # DirectoryTree

--- a/lib/PsqlWrapper.py
+++ b/lib/PsqlWrapper.py
@@ -1,4 +1,4 @@
-#!/bin/env python2.6
+#!/bin/env python
 # coding: UTF-8
 
 # PsqlWrapper

--- a/lib/TcpdumpWrapper.py
+++ b/lib/TcpdumpWrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # TcpdumpWrapper

--- a/lib/log.py
+++ b/lib/log.py
@@ -1,4 +1,4 @@
-#!/bin/env python2.6
+#!/bin/env python
 # coding: UTF-8
 
 # log

--- a/lib/testDirectoryTree.py
+++ b/lib/testDirectoryTree.py
@@ -1,4 +1,4 @@
-#!/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # testDirectoryTree

--- a/lib/testLog.py
+++ b/lib/testLog.py
@@ -1,4 +1,4 @@
-#!/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # testLog

--- a/lib/testPsqlWrapper.py
+++ b/lib/testPsqlWrapper.py
@@ -1,4 +1,4 @@
-#!/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # testPsqlWrapper

--- a/lib/testTcpdumpWrapper.py
+++ b/lib/testTcpdumpWrapper.py
@@ -1,4 +1,4 @@
-#!/bin/env python2.6
+#!/usr/bin/env python
 # coding: UTF-8
 
 # testTcpdumpWrapper
@@ -34,7 +34,7 @@ class TestTcpdmpWrapper(unittest.TestCase):
 
         self.assertTrue(str(p.ts) == '2015-04-30 21:48:12.366446')
         self.assertTrue(p.src == 'localhost.55060')
-        self.assertTrue(p.dst == 'localhost.postgres')
+        self.assertTrue(p.dst == 'localhost.postgres' or p.dst == 'localhost.postgresql')
 
     def testTcpdumpWrapper003(self):
         dump = TcpdumpWrapper.TcpdumpWrapper('127.0.0.1', '5432', 'lo', 'test.cap', debug=False)
@@ -50,7 +50,7 @@ class TestTcpdmpWrapper(unittest.TestCase):
 
         self.assertTrue(str(prev.ts) == '2015-04-30 21:48:12.413238')
         self.assertTrue(prev.src == 'localhost.55061')
-        self.assertTrue(prev.dst == 'localhost.postgres')
+        self.assertTrue(prev.dst == 'localhost.postgres' or prev.dst == 'localhost.postgresql')
 
     def testTcpdumpWrapper004(self):
         dump = TcpdumpWrapper.TcpdumpWrapper('127.0.0.1', '5432', 'lo', 'test.cap', debug=False)

--- a/src/pgperf/_build.sh
+++ b/src/pgperf/_build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 function build90()
 {

--- a/src/verifychecksum/Makefile
+++ b/src/verifychecksum/Makefile
@@ -3,7 +3,9 @@
 #
 # Copyright(c) 2015 Uptime Technologies, LLC.
 #
-CFLAGS = -Wall -g -I/usr/pgsql-9.4/include/server
+INC_SERVER=$(shell pg_config --includedir-server)
+
+CFLAGS = -Wall -g -I$(INC_SERVER)
 LIBS = 
 
 TARGET = verifychecksum.bin


### PR DESCRIPTION
  Fix shebang to specify "python" instead of "python2.6".
  Fix shebang to specify "bash" instead of "sh".
  Fix the regression test scripts to accept PostgreSQL installation path
  on Ubuntu.
  Fix CFLAGS for verifychecksum to use the pg_config command instead of
  using a fixed path.
  Fix docs.