### PR TITLE
Add pt-archive-xlog to archive xlog files in safe way. (#22)

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -9,6 +9,7 @@ check:
 
 install:
 	mkdir -p $(PREFIX)/bin
+	install -m 755 pt-archive-xlog $(PREFIX)/bin
 	install -m 755 pt-config $(PREFIX)/bin
 	install -m 755 pt-index-usage $(PREFIX)/bin
 	install -m 755 pt-kill $(PREFIX)/bin

--- a/bin/pt-archive-xlog
+++ b/bin/pt-archive-xlog
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+# pt-archive-xlog
+#
+# Copyright(c) 2015 Uptime Technologies, LLC.
+
+XLOGFILEPATH=$1
+DESTDIR=$2
+
+if [ -z "$DESTDIR" ]; then
+   BASENAME=`basename $0`
+   echo "Usage: ${BASENAME} [XLOGFILEPATH] [DESTDIR]"
+   exit 1
+fi
+
+BASENAME=`basename $XLOGFILEPATH`
+
+function do_fsync()
+{
+  sync
+  if [ $? -ne 0 ]; then
+    echo "sync failed."
+    exit 1
+  fi
+}
+
+function check_source_xlog()
+{
+  if [ ! -f $XLOGFILEPATH ]; then
+    echo "source xlog file not found."
+    exit 1
+  fi
+}
+
+function check_target_xlog()
+{
+  if [ ! -x $DESTDIR ]; then
+    echo "the destination directory not found."
+    exit 1
+  fi
+
+  if [ -f "$DESTDIR/$BASENAME" ]; then
+    cmp -s $XLOGFILEPATH "$DESTDIR/$BASENAME"
+    if [ $? -eq 0 ]; then
+      echo "the same xlog file found in the destination directory."
+      exit 0
+    else
+      echo "another xlog file found in the destination directory and two are not identical."
+      exit 1
+    fi
+  fi
+}
+
+function copy_xlog()
+{
+  rm -f "$DESTDIR/${BASENAME}_tmp"
+  cp $XLOGFILEPATH "$DESTDIR/${BASENAME}_tmp"
+  if [ $? -ne 0 ]; then
+    echo "copying a xlog file failed."
+    exit 1
+  fi
+
+  do_fsync
+
+  mv "$DESTDIR/${BASENAME}_tmp" "$DESTDIR/${BASENAME}"
+  if [ $? -ne 0 ]; then
+    echo "renaming the xlog file failed."
+    exit 1
+  fi
+}
+
+check_source_xlog
+
+check_target_xlog
+
+copy_xlog
+
+exit 0

--- a/bin/t/regress.sh
+++ b/bin/t/regress.sh
@@ -7,7 +7,7 @@ export LANG
 PGPORT=5433
 export PGPORT
 
-T="test-pt-config test-pt-index-usage test-pt-kill test-pt-proc-stat test-pt-replication-stat test-pt-session-profiler test-pt-set-tablespace test-pt-snap-statements test-pt-stat-snapshot test-pt-table-usage test-pt-tablespace-usage test-pt-verify-checksum test-pt-xact-stat"
+T="test-pt-archive-xlog test-pt-config test-pt-index-usage test-pt-kill test-pt-proc-stat test-pt-replication-stat test-pt-session-profiler test-pt-set-tablespace test-pt-snap-statements test-pt-stat-snapshot test-pt-table-usage test-pt-tablespace-usage test-pt-verify-checksum test-pt-xact-stat"
 
 function _setUp()
 {

--- a/bin/t/test-pt-archive-xlog.sh
+++ b/bin/t/test-pt-archive-xlog.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+PATH=$PATH:..:../../deps/shunit2-2.1.6/src
+export PATH
+
+. ./test_common.sh
+
+function _setUp()
+{
+    echo "PATH=$PATH"
+    echo "PGHOME=$PGHOME"
+    echo "PGDATA=$PGDATA"
+    ps auxx > setUp.log
+}
+
+function testArchiveXlog001()
+{
+    OUT=${_SHUNIT_TEST_}.out
+
+    pt-archive-xlog --help > $OUT
+    assertEquals 1 $?
+
+    cat<<EOF >${_SHUNIT_TEST_}.expected
+Usage: pt-archive-xlog [XLOGFILEPATH] [DESTDIR]
+EOF
+
+    diff -rc ${_SHUNIT_TEST_}.expected $OUT
+    assertEquals 0 $?
+}
+
+function testArchiveXlog002()
+{
+    OUT=${_SHUNIT_TEST_}.out
+
+    rm -rf /tmp/arch
+    mkdir -p /tmp/arch
+
+    # copying for the first time. (success)
+    pt-archive-xlog ${PGDATA}/pg_xlog/000000010000000000000001 /tmp/arch > $OUT
+    assertEquals 0 $?
+}
+
+function testArchiveXlog003()
+{
+    OUT=${_SHUNIT_TEST_}.out
+
+    # found the same file in the destination. (success)
+    pt-archive-xlog ${PGDATA}/pg_xlog/000000010000000000000001 /tmp/arch > $OUT
+    assertEquals 0 $?
+}
+
+function testArchiveXlog004()
+{
+    OUT=${_SHUNIT_TEST_}.out
+
+    cat /dev/null > /tmp/arch/000000010000000000000001
+
+    # found a broken file in the destination. (failure)
+    pt-archive-xlog ${PGDATA}/pg_xlog/000000010000000000000001 /tmp/arch > $OUT
+    assertEquals 1 $?
+}
+
+function testArchiveXlog005()
+{
+    OUT=${_SHUNIT_TEST_}.out
+
+    # file not found. (failure)
+    pt-archive-xlog ${PGDATA}/pg_xlog/000000010000000000000011 /tmp/arch > $OUT
+    assertEquals 1 $?
+}
+
+function testArchiveXlog006()
+{
+    OUT=${_SHUNIT_TEST_}.out
+
+    rm -f /tmp/arch/000000010000000000000001
+    chmod 000 ${PGDATA}/pg_xlog/000000010000000000000001
+
+    # (source) permission denied. (failure)
+    pt-archive-xlog ${PGDATA}/pg_xlog/000000010000000000000001 /tmp/arch > $OUT
+    assertEquals 1 $?
+
+    chmod 644 ${PGDATA}/pg_xlog/000000010000000000000001
+}
+
+function testArchiveXlog007()
+{
+    OUT=${_SHUNIT_TEST_}.out
+
+    rm -f /tmp/arch/000000010000000000000001
+    chmod 555 /tmp/arch
+
+    # (target) permission denied. (failure)
+    pt-archive-xlog ${PGDATA}/pg_xlog/000000010000000000000001 /tmp/arch > $OUT
+    assertEquals 1 $?
+
+    chmod 755 /tmp/arch
+}
+
+function testArchiveXlog008()
+{
+    OUT=${_SHUNIT_TEST_}.out
+
+    rm -rf /tmp/arch
+
+    # directory not found. (failure)
+    pt-archive-xlog ${PGDATA}/pg_xlog/000000010000000000000001 /tmp/arch > $OUT
+    assertEquals 1 $?
+}
+
+. shunit2

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -18,6 +18,7 @@ Contents:
    :maxdepth: 2
 
    install
+   pt-archive-xlog
    pt-config
    pt-index-usage
    pt-kill

--- a/docs/en/pt-archive-xlog.rst
+++ b/docs/en/pt-archive-xlog.rst
@@ -1,0 +1,35 @@
+pt-archive-xlog
+===============
+
+Summary
+-------
+
+Archive a transaction log file in safe way.
+
+This command can be used in the ``archive_command`` parameter.
+
+Usage
+-----
+
+.. code-block:: none
+
+   pt-archive-xlog <XLOGFILEPATH> <DESTDIR>
+
+Options
+-------
+
+No option.
+
+Output Items
+------------
+
+It returns with the exit code 0 on success, or 1 on failure.
+
+Examples
+--------
+
+Following example shows how to configure ``archive_command`` in ``postgresql.conf``.
+
+.. code-block:: none
+
+   archive_command = '/path/to/pt-archive-xlog %p /path/to/archivedir'

--- a/docs/ja/index.rst
+++ b/docs/ja/index.rst
@@ -16,6 +16,7 @@ Contents:
    :maxdepth: 2
 
    install
+   pt-archive-xlog
    pt-config
    pt-index-usage
    pt-kill

--- a/docs/ja/pt-archive-xlog.rst
+++ b/docs/ja/pt-archive-xlog.rst
@@ -1,0 +1,35 @@
+pt-archive-xlog
+===============
+
+概要
+----
+
+トランザクションログファイルを安全にアーカイブ処理します。
+
+``archive_command`` パラメータから呼び出すコマンドとして利用します。
+
+実行方法
+--------
+
+.. code-block:: none
+
+   pt-archive-xlog <XLOGFILEPATH> <DESTDIR>
+
+オプション
+----------
+
+特になし。
+
+出力項目
+--------
+
+アーカイブ成功時には 0 を、失敗時には 1 を返却します。
+
+実行例
+------
+
+``postgresql.conf`` の ``archive_command`` で以下のように設定します。
+
+.. code-block:: none
+
+   archive_command = '/path/to/pt-archive-xlog %p /path/to/archivedir'

--- a/installcheck.expected
+++ b/installcheck.expected
@@ -1,3 +1,4 @@
+Usage: pt-archive-xlog [XLOGFILEPATH] [DESTDIR]
 
 Usage: pt-config [option...] [command] [param [value]]
 


### PR DESCRIPTION
pt-archive-xlog allows to deal with archiving xlog files more correctly,
rather than just using cp command in the archive_command parameter.

Inspired by the talk "Warm standby done right" by Heikki Linnakangas
at pgcon2015.
http://www.pgcon.org/2015/schedule/events/811.en.html