### PR TITLE
Fix PsqlWrapper to improve the compatibility with the psql command. #39 #54

### DIFF
--- a/postgres_toolkit/PsqlWrapper.py
+++ b/postgres_toolkit/PsqlWrapper.py
@@ -115,10 +115,10 @@ class PsqlWrapper:
         if debug:
             log.setLevel(log.DEBUG)
 
-        self.host = host or os.environ.get("PGHOST", "localhost")
-        self.port = int(port or os.environ.get("PGPORT", 5432))
-        self.username = username or os.environ.get("PGUSER", os.getenv("USER"))
-        self.dbname = dbname or os.environ.get("PGDATABASE", self.username)
+        self.host = host
+        self.port = int(port) if port else None
+        self.username = username
+        self.dbname = dbname
 
         log.debug("host:   %r" % self.host)
         log.debug("port:   %r" % self.port)
@@ -137,8 +137,17 @@ class PsqlWrapper:
         return self.version
 
     def psql_cmd(self):
-        cmd = "psql -A -h {h} -p {p} -U {U} -d {d}".format(
-            h=self.host, p=self.port, U=self.username, d=self.dbname)
+        # PsqlWrapper only cares about specified values by the user explicitly,
+        # and other default values should be treated by psql properly.
+        cmd = "psql -A"
+        if self.host:
+            cmd += " -h %s" % self.host
+        if self.port:
+            cmd += " -p %s" % self.port
+        if self.username:
+            cmd += " -U %s" % self.username
+        if self.dbname:
+            cmd += " -d %s" % self.dbname
         if self.on_error_stop:
             cmd += " --set=ON_ERROR_STOP=on"
         return cmd

--- a/tests/testPsqlWrapper.py
+++ b/tests/testPsqlWrapper.py
@@ -39,25 +39,10 @@ class TestPsqlWrapper(unittest.TestCase):
         p = PsqlWrapper.PsqlWrapper(None, None, None, None)
 
         self.assertIsNotNone(p)
-        self.assertEquals('localhost', p.host)
-        self.assertEquals(5432, p.port)
-        self.assertEquals(os.getenv("USER"), p.username)
-        self.assertEquals(os.getenv("USER"), p.dbname)
-
-    def test_PsqlWrapper_003(self):
-        # Use the env vars.
-        os.environ['PGHOST'] = 'a'
-        os.environ['PGPORT'] = '1'
-        os.environ['PGUSER'] = 'b'
-        os.environ['PGDATABASE'] = 'c'
-
-        p = PsqlWrapper.PsqlWrapper(None, None, None, None)
-
-        self.assertIsNotNone(p)
-        self.assertEquals('a', p.host)
-        self.assertEquals(1, p.port)
-        self.assertEquals('b', p.username)
-        self.assertEquals('c', p.dbname)
+        self.assertIsNone(p.host)
+        self.assertIsNone(p.port)
+        self.assertIsNone(p.username)
+        self.assertIsNone(p.dbname)
 
     def test_parse_version_001(self):
         s = 'PostgreSQL 9.6.6 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-16), 64-bit'
@@ -76,6 +61,10 @@ class TestPsqlWrapper(unittest.TestCase):
     def test_psql_cmd_001(self):
         p = PsqlWrapper.PsqlWrapper('host', 1, 'user', 'db')
         self.assertEquals('psql -A -h host -p 1 -U user -d db',
+                          p.psql_cmd())
+
+        p = PsqlWrapper.PsqlWrapper(None, None, None, None)
+        self.assertEquals('psql -A',
                           p.psql_cmd())
 
         p = PsqlWrapper.PsqlWrapper('host', 1, 'user', 'db',


### PR DESCRIPTION
PsqlWrapper only cares about specified values by the user explicitly,
and other default values should be treated by psql properly.

Reported by @nori-shinoda