### PR TITLE
Change TRUE/FALSE to true/false

### DIFF
--- a/src/verifychecksum/verifychecksum.c
+++ b/src/verifychecksum/verifychecksum.c
@@ -49,10 +49,10 @@ verify_page(const char *page, BlockNumber blkno, const char *filepath)
     {
       printf("%s: blkno %d, page header %x, calculated %x\n",
 	     filepath, blkno, phdr->pd_checksum, checksum);
-      return FALSE;
+      return false;
     }
 
-  return TRUE;
+  return true;
 }
 
 int
@@ -93,13 +93,13 @@ verify_segmentfile(const char *filepath)
   if (corrupted > 0)
     {
       printf("%d blocks corrupted in %s.\n", corrupted, filepath);
-      return FALSE;
+      return false;
     }
 
   if (verbose)
     printf("Verified %d blocks in %s.\n", blkno, filepath);
 
-  return TRUE;
+  return true;
 }
 
 int


### PR DESCRIPTION
PostgreSQL 11 removed the TRUE/FALSE defines in commit https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=6337865f36da34e9c89aaa292f976bde6df0b065

Convert to true/false so that verifychecksum.c continues to build against newer versions of PostgreSQL.

Fixes uptimejp/postgres-toolkit#70